### PR TITLE
Oracle Database 11g XE (11.2.0) on Ubuntu Server 16.04.4 LTS (x86-64) Installation/Deinstallation Instructions.

### DIFF
--- a/ubuntusrv/oracle-11-2-0-xe-on-ubuntu-16-04-4-lts.md
+++ b/ubuntusrv/oracle-11-2-0-xe-on-ubuntu-16-04-4-lts.md
@@ -172,7 +172,20 @@ Apr 06 17:38:26 <hostname> systemd[1]: Started SYSV: This is a program that is r
 
 ### Connect to the running Oracle Database instance (and get some data)
 
-Before executing any of Oracle Database utilities it needs to set appropriate environment variables:
+Before executing any of Oracle Database utilities it needs to add the current user to the `dba` group and set appropriate environment variables:
+
+```
+$ sudo usermod -a -G dba <username>
+```
+
+Do relogin and check the current user is now a DBA:
+
+```
+$ groups
+<usergroup> dba
+```
+
+Set Oracle Database-related environment variables:
 
 ```
 $ . /u01/app/oracle/product/11.2.0/xe/bin/oracle_env.sh

--- a/ubuntusrv/ubuntu-16-04-4-lts-wo-oracle-11-2-0-xe.md
+++ b/ubuntusrv/ubuntu-16-04-4-lts-wo-oracle-11-2-0-xe.md
@@ -1,0 +1,77 @@
+# Oracle Database 11*g* XE (11.2.0) on Ubuntu Server 16.04.4 LTS (x86-64) Deinstallation Instructions
+
+## (1) Stop the running Oracle Database 11.2.0 XE instance
+
+```
+$ sudo /etc/init.d/oracle-xe stop
+[ ok ] Stopping oracle-xe (via systemctl): oracle-xe.service.
+```
+
+## (2) Uninstall (and purge configuration files) the Oracle Database 11.2.0 XE instance and its components
+
+Use the `dpkg` utility to:
+
+### (a) Ensure the `oracle-xe` package is installed and registered in the system package database (optional)
+
+```
+$ dpkg --get-selections | grep oracle-xe
+oracle-xe                                       install
+```
+
+### (b) Purge (uninstall) the `oracle-xe` package from the system and unregister it from the system package database
+
+```
+$ sudo dpkg -P oracle-xe
+(Reading database ... 145312 files and directories currently installed.)
+Removing oracle-xe (11.2.0-2) ...
+Purging configuration files for oracle-xe (11.2.0-2) ...
+dpkg: warning: while removing oracle-xe, directory '/u01/app/oracle/product/11.2.0/xe/lib' not empty so not removed
+dpkg: warning: while removing oracle-xe, directory '/u01/app/oracle/product/11.2.0/xe/config' not empty so not removed
+dpkg: warning: while removing oracle-xe, directory '/u01/app/oracle/product/11.2.0/xe/dbs' not empty so not removed
+dpkg: warning: while removing oracle-xe, directory '/u01/app/oracle/product/11.2.0/xe/network' not empty so not removed
+Processing triggers for libc-bin (2.23-0ubuntu10) ...
+Processing triggers for mime-support (3.59ubuntu1) ...
+```
+
+### Manually remove remaining directories and files from the system
+
+Notice from the previous command execution output there are a series of directories not removed, which are not actually needed. These directories should also be removed. For that simply delete the `/u01` directory recursively:
+
+```
+$ sudo rm -Rf /u01
+```
+
+Remove remaining Oracle Database-related directories and files which are still exist in the system for any reason:
+
+```
+$ sudo rm -Rf /etc/default/oracle-xe \
+              /etc/oratab            \
+              /tmp/.oracle           \
+              /var/tmp/.oracle       \
+              ~/oradiag_<username>   \
+              ~/.rpmdb
+```
+
+## (3) Remove the user who acts as a DBA from the `dba` group
+
+```
+$ sudo gpasswd -d <username> dba
+Removing user <username> from group dba
+```
+
+Do relogin and check the DBA user is not a DBA anymore:
+
+```
+$ groups
+<usergroup>
+```
+
+(It previously was looked like the following:)
+```
+$ groups
+<usergroup> dba
+```
+
+---
+
+Happy deliverance from Oracle in Ubuntu ! :+1: -- Because **PostgreSQL** will rule the Universe ! :blue_heart:


### PR DESCRIPTION
- Adding instructions for uninstalling **Oracle Database** 11.2.0 XE from **Ubuntu Server** 16.04.4 LTS.
- Oracle Database 11g XE Installation Instructions: Adding forgotten command to enroll the current user into the DBA group.